### PR TITLE
Unique option removed for whiteboard file names in database

### DIFF
--- a/node_server/models/circles.js
+++ b/node_server/models/circles.js
@@ -89,7 +89,7 @@ const CircleSchema = new mongoose.Schema({
     whiteboardFiles: [{
       name: {
         type:       String,
-        unique:     true,
+        unique:     false,
         required:   true,
         trim:       true,
       },


### PR DESCRIPTION
Fixes the following error with database:

```
UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "World creation error: E11000 duplicate key error collection: circles.circles index: whiteboardFiles.name_1 dup key: { whiteboardFiles.name: null }".
    at throwUnhandledRejectionsMode (node:internal/process/promises:392:7)
    at processPromiseRejections (node:internal/process/promises:475:17)
    at process.processTicksAndRejections (node:internal/process/task_queues:106:32) {
  code: 'ERR_UNHANDLED_REJECTION'
}
```

Where the unique option was enforcing the whiteboard file name to be unique across all documents instead of the individual whiteboard file array. 

Error solved by removing the unique option as it is enforced during document creation.