### PR TITLE
Variable type and default value mismatch fixed in circles trigger component

### DIFF
--- a/src/components/circles-trigger.js
+++ b/src/components/circles-trigger.js
@@ -8,7 +8,7 @@ AFRAME.registerComponent('circles-trigger',
         isEnabled:          {type:'bool',       default:true},
         isEventsEnabled:    {type:'bool',       default:true},
         isVisible:          {type:'bool',       default:true},
-        opacity:            {type:'float',      default:'0.5'},
+        opacity:            {type:'float',      default:0.5},
         radius:             {type:'float',      default:2.0},
         targetId:           {type:'string',     default:'#Player1'}
     }, 


### PR DESCRIPTION
`opacity` schema variable default value updated to be a float instead of a string in circles trigger component