### PR TITLE
Network pickup bug fixed

### DIFF
--- a/src/components/circles-pickup-networked.js
+++ b/src/components/circles-pickup-networked.js
@@ -201,9 +201,11 @@ AFRAME.registerComponent('circles-pickup-networked', {
 
     CONTEXT_AF.pickupObjFunc_Sync = function(data) {
       //console.log('pickupObjFunc_Sync ', CONTEXT_AF.el.id);
-      CONTEXT_AF.el.emit(CIRCLES.EVENTS.SYNC_PICKUP_THIS_OBJECT);
 
       CONTEXT_AF.isPickedUp = true;
+
+      document.querySelector('#' + data.id)?.emit(CIRCLES.EVENTS.SYNC_PICKUP_THIS_OBJECT);
+      document.querySelector('#' + data.origId)?.emit(CIRCLES.EVENTS.SYNC_PICKUP_THIS_OBJECT);
 
         const isSameWorld = (data.origWorld === CIRCLES.getCirclesWorldName());
         const isSameElem  = (data.origId === CONTEXT_AF.el.components['circles-object-world'].data.id);
@@ -234,9 +236,11 @@ AFRAME.registerComponent('circles-pickup-networked', {
 
     CONTEXT_AF.releaseObjFunc_Sync = function(data) {
       //console.log('releaseObjFunc_Sync ', data);
-      CONTEXT_AF.el.emit(CIRCLES.EVENTS.SYNC_RELEASE_THIS_OBJECT);
 
       CONTEXT_AF.isPickedUp = false;
+
+      document.querySelector('#' + data.id)?.emit(CIRCLES.EVENTS.SYNC_RELEASE_THIS_OBJECT);
+      document.querySelector('#' + data.origId)?.emit(CIRCLES.EVENTS.SYNC_RELEASE_THIS_OBJECT);
 
       const isSameWorld = (data.origWorld === CIRCLES.getCirclesWorldName());
       const isSameElem  = (data.origId === CONTEXT_AF.el.components['circles-object-world'].data.id);
@@ -421,6 +425,8 @@ AFRAME.registerComponent('circles-pickup-networked', {
     let isSameElem  = false;
     const allNetworkObjects = document.querySelectorAll('[circles-pickup-networked]');
     allNetworkObjects.forEach(function(netObj) {
+      if (!netObj.components['circles-object-world']) return;
+
       isSameWorld = (netObj.components['circles-object-world'].data.world === CIRCLES.getCirclesWorldName());
       isSameElem  = (netObj.components['circles-object-world'].data.id === CONTEXT_AF.el.components['circles-object-world'].data.id);
 

--- a/src/components/circles-pickup-object.js
+++ b/src/components/circles-pickup-object.js
@@ -132,6 +132,8 @@ AFRAME.registerComponent('circles-pickup-object', {
     const data        = CONTEXT_AF.data;
     const SAME_DIFF   = 0.001;
 
+    if (!CONTEXT_AF.pickedUp) return;
+
     //release
     CONTEXT_AF.origParent.object3D.attach(CONTEXT_AF.el.object3D); //using three's "attach" allows us to retain world transforms during pickup/release
 


### PR DESCRIPTION
Fixed networked pickup bug that hides UI when a networked user picks up a different object by updating circles pickup object to have an error check ensuring the current object is picked up before releasing