### PR TITLE
Circles manager component bug fixed

### DIFF
--- a/src/components/circles-manager.js
+++ b/src/components/circles-manager.js
@@ -210,7 +210,7 @@ AFRAME.registerComponent('circles-manager', {
   },
   isExperienceEntered : function() {
     //let everyone know that circles is ready
-    return this.isExperienceEntered;
+    return this.isExperienceEnteredVar;
   },
   addEventListeners : function () {
     const CONTEXT_AF  = this;


### PR DESCRIPTION
`isExperienceEntered()` returns variable indicating whether experience has been entered instead of the function itself